### PR TITLE
Delete one broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,6 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Algorithm design canvas](https://www.hiredintech.com/algorithm-design)
 - [Aptitude Questions and Answers](http://www.indiabix.com) : Quant and aptitude preparation
 - [A site for technical interview questions, brain teasers, puzzles, quizzles](https://www.techinterview.org) : whatever the heck those are) and other things that make you think!
-- [BeehYve](https://www.beehyve.io) : Student crowdsourced resources for any topic
 - [Big collection of interview preparation links • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/2lzc4h/big_collection_of_interview_preparation_links/)
 - [Big-O Algorithm Complexity Cheat Sheet](http://bigocheatsheet.com/#)
 - [BIG O Misconceptions](http://ssp.impulsetrain.com/big-o.html)


### PR DESCRIPTION
The link and intro of "BeehYve : Student crowdsourced resources for any topic" in the "Interview Preparation" section was removed because the link is no longer accessible.